### PR TITLE
Add workdir property to the Hap

### DIFF
--- a/examples/nested/samename.py
+++ b/examples/nested/samename.py
@@ -1,0 +1,6 @@
+def main():
+    print("Malicious code execution", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/samename.py
+++ b/examples/samename.py
@@ -1,0 +1,6 @@
+def main():
+    print("Correct file is being run", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/hapless/formatters.py
+++ b/hapless/formatters.py
@@ -60,11 +60,16 @@ class TableFormatter(Formatter):
             status_table.add_row("Return code:", f"{hap.rc}")
 
         cmd_text = Text(f"{hap.cmd}", style=f"{config.COLOR_ACCENT} bold")
-        status_table.add_row("Command:", cmd_text)
+        if self.verbose:
+            status_table.add_row("")
+            status_table.add_row("Command:", cmd_text)
+            status_table.add_row("Working dir:", f"{hap.workdir}")
+            status_table.add_row("")
+        else:
+            status_table.add_row("Command:", cmd_text)
 
         proc = hap.proc
         if self.verbose and proc is not None:
-            status_table.add_row("Working dir:", f"{proc.cwd()}")
             status_table.add_row("Parent PID:", f"{proc.ppid()}")
             status_table.add_row("User:", f"{proc.username()}")
 

--- a/hapless/hap.py
+++ b/hapless/hap.py
@@ -196,9 +196,9 @@ class Hap(object):
 
     @property
     @allow_missing
-    def workdir(self) -> Optional[str]:
+    def workdir(self) -> Optional[Path]:
         with open(self._workdir_file) as f:
-            return f.read()
+            return Path(f.read())
 
     @property
     @allow_missing

--- a/hapless/hap.py
+++ b/hapless/hap.py
@@ -256,8 +256,8 @@ class Hap(object):
         if proc is not None:
             return proc.environ()
 
-        with open(self._env_file) as env_file:
-            return json.loads(env_file.read())
+        with open(self._env_file) as f:
+            return json.loads(f.read())
 
     @property
     @allow_missing

--- a/hapless/hap.py
+++ b/hapless/hap.py
@@ -323,7 +323,7 @@ class Hap(object):
             "pid": str(self.pid) if self.pid is not None else None,
             "rc": str(self.rc) if self.rc is not None else None,
             "cmd": self.cmd,
-            "workdir": self.workdir,
+            "workdir": str(self.workdir),
             "status": self.status.value,
             "runtime": self.runtime,
             "start_time": self.start_time,

--- a/hapless/hap.py
+++ b/hapless/hap.py
@@ -190,13 +190,13 @@ class Hap(object):
 
     @property
     @allow_missing
-    def cmd(self) -> str:
+    def cmd(self) -> Optional[str]:
         with open(self._cmd_file) as f:
             return f.read()
 
     @property
     @allow_missing
-    def workdir(self) -> str:
+    def workdir(self) -> Optional[str]:
         with open(self._workdir_file) as f:
             return f.read()
 

--- a/hapless/hap.py
+++ b/hapless/hap.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 try:
     from functools import cached_property
@@ -23,8 +23,9 @@ from hapless.utils import allow_missing, get_mtime, logger
 
 
 class Status(str, Enum):
-    # Active statuses
+    # Created status
     UNBOUND = "unbound"
+    # Active statuses
     PAUSED = "paused"
     RUNNING = "running"
     # Finished statuses
@@ -39,6 +40,7 @@ class Hap(object):
         *,
         name: Optional[str] = None,
         cmd: Optional[str] = None,
+        workdir: Optional[Union[str, Path]] = None,
         redirect_stderr: bool = False,
     ) -> None:
         if not hap_path.is_dir():
@@ -51,6 +53,7 @@ class Hap(object):
         self._rc_file = hap_path / "rc"
         self._name_file = hap_path / "name"
         self._cmd_file = hap_path / "cmd"
+        self._workdir_file = hap_path / "workdir"
         self._env_file = hap_path / "env"
 
         self._stdout_path = hap_path / "stdout.log"
@@ -58,7 +61,7 @@ class Hap(object):
 
         self._set_logfiles(redirect_stderr)
         self._set_raw_name(name)
-        self._set_cmd(cmd)
+        self._set_command_context(cmd, workdir)
 
     def set_name(self, name: str):
         with open(self._name_file, "w") as f:
@@ -79,15 +82,29 @@ class Hap(object):
         if self.raw_name is None:
             self.set_name(raw_name)
 
-    def _set_cmd(self, cmd: Optional[str]):
+    def _set_command_context(
+        self,
+        cmd: Optional[str],
+        workdir: Optional[Union[str, Path]],
+    ) -> None:
         """
-        Set cmd for the first time on hap creation.
+        Set command and working directory for the first time on hap creation.
         """
         if self.cmd is None:
             if cmd is None:
                 raise ValueError("Command to run is not provided")
             with open(self._cmd_file, "w") as f:
                 f.write(cmd)
+
+        if self.workdir is None:
+            workdir = Path(workdir or os.getcwd())
+            # NOTE: should be ValueError, but we need defaults to keep
+            # compatibility with the older versions
+            if not workdir.exists() or not workdir.is_dir():
+                raise ValueError("Workdir should be a path to existing directory")
+
+            with open(self._workdir_file, "w") as f:
+                f.write(f"{workdir}")
 
     def _set_pid(self, pid: int):
         with open(self._pid_file, "w") as pid_file:
@@ -175,6 +192,12 @@ class Hap(object):
     @allow_missing
     def cmd(self) -> str:
         with open(self._cmd_file) as f:
+            return f.read()
+
+    @property
+    @allow_missing
+    def workdir(self) -> str:
+        with open(self._workdir_file) as f:
             return f.read()
 
     @property

--- a/hapless/hap.py
+++ b/hapless/hap.py
@@ -323,6 +323,7 @@ class Hap(object):
             "pid": str(self.pid) if self.pid is not None else None,
             "rc": str(self.rc) if self.rc is not None else None,
             "cmd": self.cmd,
+            "workdir": self.workdir,
             "status": self.status.value,
             "runtime": self.runtime,
             "start_time": self.start_time,

--- a/hapless/main.py
+++ b/hapless/main.py
@@ -173,15 +173,17 @@ class Hapless:
         )
         return_code: Optional[int] = hap.rc
         if return_code is None:
+            # no return code yet, process is still running
             self.ui.print(
                 f"{config.ICON_INFO} Hap is healthy "
                 f"and still running after {timeout} seconds",
                 style=f"{config.COLOR_ACCENT} bold",
             )
         elif return_code == 0:
+            # finished quickly, but successfully
             self.ui.print(
-                f"{config.ICON_INFO} Hap is healthy "
-                f"and still running after {timeout} seconds",
+                f"{config.ICON_INFO} Hap finished successfully "
+                f"in less than {timeout} seconds",
                 style=f"{config.COLOR_ACCENT} bold",
             )
         else:

--- a/hapless/main.py
+++ b/hapless/main.py
@@ -165,24 +165,30 @@ class Hapless:
 
     def _check_fast_failure(self, hap: Hap) -> None:
         timeout = config.FAILFAST_TIMEOUT
-        if (
-            wait_created(
-                hap._rc_file,
-                live_context=self.ui.get_live(),
-                interval=0.5,
-                timeout=timeout,
+        wait_created(
+            hap._rc_file,
+            live_context=self.ui.get_live(),
+            interval=0.5,
+            timeout=timeout,
+        )
+        return_code: Optional[int] = hap.rc
+        if return_code is None:
+            self.ui.print(
+                f"{config.ICON_INFO} Hap is healthy "
+                f"and still running after {timeout} seconds",
+                style=f"{config.COLOR_ACCENT} bold",
             )
-            and hap.rc != 0
-        ):
+        elif return_code == 0:
+            self.ui.print(
+                f"{config.ICON_INFO} Hap is healthy "
+                f"and still running after {timeout} seconds",
+                style=f"{config.COLOR_ACCENT} bold",
+            )
+        else:
+            # non-zero return code
             self.ui.error("Hap exited too quickly. stderr message:")
             self.ui.print(hap.stderr_path.read_text())
             sys.exit(1)
-
-        self.ui.print(
-            f"{config.ICON_INFO} Hap is healthy "
-            f"and still running after {timeout} seconds",
-            style=f"{config.COLOR_ACCENT} bold",
-        )
 
     def run_hap(
         self,

--- a/hapless/main.py
+++ b/hapless/main.py
@@ -140,7 +140,6 @@ class Hapless:
             stderr_pipe = stdout_pipe
             if not hap.redirect_stderr:
                 stderr_pipe = open(hap.stderr_path, "w")
-            self.ui.print(f"{config.ICON_INFO} Launching", hap)
             shell_exec = os.getenv("SHELL")
             if shell_exec is not None:
                 logger.debug(f"Using {shell_exec} to run hap")
@@ -202,6 +201,7 @@ class Hapless:
             self._wrap_subprocess(hap)
             return
 
+        self.ui.print(f"{config.ICON_INFO} Launching", hap)
         # TODO: or sys.platform == "win32"
         if config.NO_FORK:
             logger.debug("Forking is disabled, running using spawn via wrapper")

--- a/hapless/main.py
+++ b/hapless/main.py
@@ -146,6 +146,7 @@ class Hapless:
                 logger.debug(f"Using {shell_exec} to run hap")
             proc = subprocess.Popen(
                 hap.cmd,
+                cwd=hap.workdir,
                 shell=True,
                 executable=shell_exec,
                 stdout=stdout_pipe,
@@ -372,6 +373,7 @@ class Hapless:
 
         hap_killed = self.get_hap(hid)
         while hap_killed.active:
+            # NOTE: re-read is required as `proc` is a cached property
             hap_killed = self.get_hap(hid)
 
         rc_exists = wait_created(hap_killed._rc_file, timeout=1)

--- a/hapless/main.py
+++ b/hapless/main.py
@@ -163,7 +163,7 @@ class Hapless:
 
         hap.set_return_code(retcode)
 
-    def _check_fast_failure(self, hap: Hap):
+    def _check_fast_failure(self, hap: Hap) -> None:
         timeout = config.FAILFAST_TIMEOUT
         if (
             wait_created(
@@ -333,7 +333,7 @@ class Hapless:
         else:
             self.ui.error("Nothing to clean")
 
-    def kill(self, haps: List[Hap], verbose: bool = True):
+    def kill(self, haps: List[Hap], verbose: bool = True) -> int:
         killed_counter = 0
         for hap in haps:
             if hap.active:
@@ -348,6 +348,7 @@ class Hapless:
             )
         elif verbose:
             self.ui.error("No active haps to kill")
+        return killed_counter
 
     def signal(self, hap: Hap, sig: signal.Signals):
         if hap.active:

--- a/hapless/utils.py
+++ b/hapless/utils.py
@@ -6,20 +6,24 @@ import time
 from contextlib import nullcontext
 from functools import wraps
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional, TypeVar
 
 import click
 import psutil
 import structlog
 from rich.spinner import Spinner
 from rich.text import Text
+from typing_extensions import ParamSpec
 
 from hapless import config
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-def allow_missing(func):
+
+def allow_missing(func: Callable[P, R]) -> Callable[P, Optional[R]]:
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[R]:
         try:
             return func(*args, **kwargs)
         except FileNotFoundError:

--- a/hapless/utils.py
+++ b/hapless/utils.py
@@ -97,7 +97,12 @@ def kill_proc_tree(pid, sig=signal.SIGKILL, include_parent=True):
     if pid == os.getpid():
         raise ValueError("Would not kill myself")
 
-    parent = psutil.Process(pid)
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        logger.warning(f"Process {pid} is already gone, nothing to kill")
+        return
+
     children = parent.children(recursive=True)
     if include_parent:
         children.append(parent)

--- a/poetry.lock
+++ b/poetry.lock
@@ -188,17 +188,14 @@ testing = ["coverage[toml] (>=5.0a4)", "pytest (>=4.6.11)", "setuptools (>=71.0.
 
 [[package]]
 name = "exceptiongroup"
-version = "1.3.0"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
-    {file = "exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"},
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
 test = ["pytest (>=6)"]
@@ -585,13 +582,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.7.1"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+version = "4.0.0"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
-    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
+    {file = "typing_extensions-4.0.0-py3-none-any.whl", hash = "sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9"},
+    {file = "typing_extensions-4.0.0.tar.gz", hash = "sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed"},
 ]
 
 [[package]]
@@ -635,4 +632,4 @@ dev = ["pytest", "pytest-cov", "pytest-env", "pytest-env", "ruff"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "0a8dfe76a0388a9387e0f63c90452119256f2315095de7aa16fcdd2f341f846d"
+content-hash = "7df28cd0adcaf3b005c25e27502eb1c3828bdbb7787ff042684dc75b66e92220"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hapless"
-version = "0.10.0"
+version = "0.11.0"
 description = "Run and track processes in background"
 authors = ["Misha Behersky <bmwant@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ pytest-env = [
     { version = "0.8.2", python = "<3.8", optional = true },
     { version = "^1.1.2", python = ">=3.8", optional = true },
 ]
+typing-extensions = "4.0.0"
 
 
 [tool.poetry.extras]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from typing import Generator
 from unittest.mock import patch
@@ -37,7 +38,8 @@ def hap(tmpdir) -> Generator[Hap, None, None]:
 
 
 @pytest.fixture
-def hapless(tmpdir) -> Generator[Hapless, None, None]:
+def hapless(tmpdir, monkeypatch) -> Generator[Hapless, None, None]:
+    monkeypatch.chdir(tmpdir)
     yield Hapless(hapless_dir=Path(tmpdir), quiet=True)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,15 +32,15 @@ def runner() -> Generator[CliRunner, None, None]:
 
 
 @pytest.fixture
-def hap(tmpdir) -> Generator[Hap, None, None]:
-    hapless = Hapless(hapless_dir=Path(tmpdir))
+def hap(tmp_path) -> Generator[Hap, None, None]:
+    hapless = Hapless(hapless_dir=tmp_path)
     yield hapless.create_hap("false")
 
 
 @pytest.fixture
-def hapless(tmpdir, monkeypatch) -> Generator[Hapless, None, None]:
-    monkeypatch.chdir(tmpdir)
-    yield Hapless(hapless_dir=Path(tmpdir), quiet=True)
+def hapless(tmp_path, monkeypatch) -> Generator[Hapless, None, None]:
+    monkeypatch.chdir(tmp_path)
+    yield Hapless(hapless_dir=tmp_path, quiet=True)
 
 
 @pytest.fixture(name="log_output")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 from typing import Generator
 from unittest.mock import patch
@@ -32,13 +31,13 @@ def runner() -> Generator[CliRunner, None, None]:
 
 
 @pytest.fixture
-def hap(tmp_path) -> Generator[Hap, None, None]:
+def hap(tmp_path: Path) -> Generator[Hap, None, None]:
     hapless = Hapless(hapless_dir=tmp_path)
     yield hapless.create_hap("false")
 
 
 @pytest.fixture
-def hapless(tmp_path, monkeypatch) -> Generator[Hapless, None, None]:
+def hapless(tmp_path: Path, monkeypatch) -> Generator[Hapless, None, None]:
     monkeypatch.chdir(tmp_path)
     yield Hapless(hapless_dir=tmp_path, quiet=True)
 

--- a/tests/test_hap.py
+++ b/tests/test_hap.py
@@ -51,6 +51,7 @@ def test_unbound_hap(hap: Hap):
     assert hap.accessible is True
     # Current user should be the owner of the hap
     assert hap.owner == getpass.getuser()
+    assert hap.workdir == os.getcwd()
 
 
 def test_hap_path_should_be_a_directory(tmp_path):

--- a/tests/test_hap.py
+++ b/tests/test_hap.py
@@ -1,4 +1,5 @@
 import getpass
+import json
 import os
 import re
 from io import StringIO
@@ -51,7 +52,8 @@ def test_unbound_hap(hap: Hap):
     assert hap.accessible is True
     # Current user should be the owner of the hap
     assert hap.owner == getpass.getuser()
-    assert hap.workdir == os.getcwd()
+    assert isinstance(hap.workdir, Path)
+    assert str(hap.workdir) == os.getcwd()
 
 
 def test_hap_path_should_be_a_directory(tmp_path):
@@ -124,6 +126,10 @@ def test_serialize(hap: Hap):
     assert serialized["restarts"] == str(hap.restarts)
     assert serialized["stdout_file"] == str(hap.stdout_path)
     assert serialized["stderr_file"] == str(hap.stderr_path)
+    # check all the fields are json-serializable
+    result = json.dumps(serialized)
+    assert isinstance(result, str)
+    assert "workdir" in result
 
 
 def test_represent_unbound_hap(hapless: Hapless, capsys):

--- a/tests/test_hap_workdir.py
+++ b/tests/test_hap_workdir.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from hapless.hap import Hap, Status
+from hapless.main import Hapless
+
+
+def all_equal(iterable):
+    return len(set(iterable)) <= 1
+
+
+def test_random_name_generation():
+    name_length = 8
+    name_count = 4
+    names = []
+    for _ in range(name_count):
+        new_name = Hap.get_random_name(length=name_length)
+        assert len(new_name) == name_length
+        names.append(new_name)
+
+    assert not all_equal(names)
+
+
+def test_unbound_hap(hap: Hap):
+    assert isinstance(hap.name, str)
+    assert hap.name.startswith("hap-")
+    assert hap.pid is None
+    assert hap.proc is None
+    assert hap.rc is None
+    assert hap.cmd == "false"
+    assert hap.status == Status.UNBOUND
+    assert hap.env is None
+    assert hap.restarts == 0
+    assert not hap.active

--- a/tests/test_hapless.py
+++ b/tests/test_hapless.py
@@ -209,7 +209,11 @@ def test_run_command_accepts_redirect_stderr_parameter(hapless: Hapless):
     ) as create_hap_mock:
         hapless.run_command("echo redirect", redirect_stderr=True)
         create_hap_mock.assert_called_once_with(
-            cmd="echo redirect", hid=None, name=None, redirect_stderr=True
+            cmd="echo redirect",
+            workdir=None,
+            hid=None,
+            name=None,
+            redirect_stderr=True,
         )
         run_hap_mock.assert_called_once_with(hap_mock, check=False, blocking=False)
 
@@ -306,6 +310,7 @@ def test_restart_preserves_redirect_state(hapless: Hapless, redirect_stderr: boo
         wait_created_mock.assert_called_once_with(ANY, timeout=1)
         run_command_mock.assert_called_once_with(
             cmd="doesnotexist",
+            workdir=f"{hapless.dir}",
             hid=hid,
             name="hap-redirect-state@1",
             redirect_stderr=redirect_stderr,

--- a/tests/test_hapless.py
+++ b/tests/test_hapless.py
@@ -102,10 +102,10 @@ def test_get_haps_return_all_entries(hapless: Hapless):
         assert access_mock.call_count == 3
 
 
-def test_state_dir_is_not_accessible(tmpdir, capsys):
+def test_state_dir_is_not_accessible(tmp_path, capsys):
     with patch("os.utime", side_effect=PermissionError):
         with pytest.raises(SystemExit) as e:
-            Hapless(hapless_dir=Path(tmpdir))
+            Hapless(hapless_dir=tmp_path)
 
         captured = capsys.readouterr()
 
@@ -113,16 +113,16 @@ def test_state_dir_is_not_accessible(tmpdir, capsys):
         assert e.value.code == 1
 
 
-def test_state_dir_is_overriden(tmpdir):
-    custom_state_dir = f"{tmpdir}/custom"
+def test_state_dir_is_overriden(tmp_path: Path):
+    custom_state_dir = tmp_path / "custom"
     hapless = Hapless(hapless_dir=custom_state_dir)
 
     assert isinstance(hapless.dir, Path)
-    assert str(hapless.dir) == custom_state_dir
+    assert hapless.dir == custom_state_dir
 
     hap = hapless.create_hap(cmd="echo hello", hid="42", name="hap-name")
-    assert hap.path.parent == Path(custom_state_dir)
-    assert hap.path == Path(custom_state_dir) / hap.hid
+    assert hap.path.parent == custom_state_dir
+    assert hap.path == custom_state_dir / hap.hid
 
 
 def test_run_hap_invocation(hapless: Hapless):
@@ -317,8 +317,8 @@ def test_restart_preserves_redirect_state(hapless: Hapless, redirect_stderr: boo
         )
 
 
-def test_same_handle_can_be_closed_twice(tmpdir):
-    filepath = Path(tmpdir) / "samehandle.log"
+def test_same_handle_can_be_closed_twice(tmp_path):
+    filepath = tmp_path / "samehandle.log"
     filepath.touch()
     stdout_handle = filepath.open("w")
     stderr_handle = stdout_handle

--- a/tests/test_hapless.py
+++ b/tests/test_hapless.py
@@ -310,7 +310,7 @@ def test_restart_preserves_redirect_state(hapless: Hapless, redirect_stderr: boo
         wait_created_mock.assert_called_once_with(ANY, timeout=1)
         run_command_mock.assert_called_once_with(
             cmd="doesnotexist",
-            workdir=f"{hapless.dir}",
+            workdir=hapless.dir,
             hid=hid,
             name="hap-redirect-state@1",
             redirect_stderr=redirect_stderr,
@@ -359,6 +359,7 @@ def test_wrap_subprocess(hapless: Hapless):
         bind_mock.assert_called_once_with(12345)
         popen_mock.assert_called_once_with(
             "echo subprocess",
+            cwd=hap.workdir,
             shell=True,
             executable=ANY,
             stdout=ANY,

--- a/tests/test_lib_usage.py
+++ b/tests/test_lib_usage.py
@@ -6,8 +6,8 @@ import pytest
 from hapless import Hap, Hapless, Status
 
 
-def test_creation(tmpdir):
-    hapless = Hapless(hapless_dir=Path(tmpdir))
+def test_creation(tmp_path):
+    hapless = Hapless(hapless_dir=tmp_path)
     hap1 = hapless.create_hap("echo one", name="hap-one")
     hap2 = hapless.create_hap("echo two", name="hap-two")
 
@@ -20,11 +20,11 @@ def test_creation(tmpdir):
     assert hap1.status == Status.UNBOUND
 
 
-def test_quiet_mode(tmpdir, capsys):
+def test_quiet_mode(tmp_path, capsys):
     """
     Check that quiet mode suppresses output.
     """
-    hapless = Hapless(hapless_dir=Path(tmpdir), quiet=True)
+    hapless = Hapless(hapless_dir=tmp_path, quiet=True)
     hap = hapless.create_hap("false")
     with pytest.raises(SystemExit) as e:
         hapless.pause_hap(hap)

--- a/tests/test_lib_usage.py
+++ b/tests/test_lib_usage.py
@@ -6,7 +6,7 @@ import pytest
 from hapless import Hap, Hapless, Status
 
 
-def test_creation(tmp_path):
+def test_creation(tmp_path: Path):
     hapless = Hapless(hapless_dir=tmp_path)
     hap1 = hapless.create_hap("echo one", name="hap-one")
     hap2 = hapless.create_hap("echo two", name="hap-two")
@@ -20,7 +20,7 @@ def test_creation(tmp_path):
     assert hap1.status == Status.UNBOUND
 
 
-def test_quiet_mode(tmp_path, capsys):
+def test_quiet_mode(tmp_path: Path, capsys):
     """
     Check that quiet mode suppresses output.
     """

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, PropertyMock, patch
 
 import pytest
 
+from hapless import config
 from hapless.formatters import TableFormatter
 from hapless.main import Hapless
 from hapless.ui import ConsoleUI
@@ -197,6 +198,7 @@ def test_check_fast_failure_error_message(hapless_with_ui: Hapless, capsys):
 
 def test_check_fast_failure_quick_but_success(hapless_with_ui: Hapless, capsys):
     hapless = hapless_with_ui
+    timeout = config.FAILFAST_TIMEOUT
     hap = hapless.create_hap("true", name="hap-check-fast-ok")
     with patch.object(
         type(hap), "rc", new_callable=PropertyMock, return_value=0
@@ -208,9 +210,10 @@ def test_check_fast_failure_quick_but_success(hapless_with_ui: Hapless, capsys):
             hap._rc_file,
             live_context=ANY,
             interval=ANY,
-            timeout=ANY,
+            timeout=timeout,
         )
 
     captured = capsys.readouterr()
-    assert "Hap exited too quickly" in captured.out
+    assert f"Hap finished successfully in less than {timeout} seconds" in captured.out
+    assert "Hap exited too quickly" not in captured.out
     assert "Hap is healthy" not in captured.out

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -100,3 +100,17 @@ def test_rename_message(hapless_with_ui: Hapless, capsys):
     assert "Renamed" in captured.out
     assert "old-name" in captured.out
     assert "new-name" in captured.out
+
+
+def test_workdir_is_displayed_in_versbose_mode(
+    hapless_with_ui: Hapless, tmpdir, capsys
+):
+    hapless = hapless_with_ui
+    workdir = Path(tmpdir)
+    hap = hapless.create_hap("true", workdir=workdir)
+    hapless.show(hap, formatter=TableFormatter(verbose=True))
+
+    captured = capsys.readouterr()
+    assert "Command:" in captured.out
+    assert "Working dir:" in captured.out
+    assert f"{workdir}" in captured.out  # Check for the title

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -193,3 +193,24 @@ def test_check_fast_failure_error_message(hapless_with_ui: Hapless, capsys):
     captured = capsys.readouterr()
     assert "Hap exited too quickly" in captured.out
     assert "Hap is healthy" not in captured.out
+
+
+def test_check_fast_failure_quick_but_success(hapless_with_ui: Hapless, capsys):
+    hapless = hapless_with_ui
+    hap = hapless.create_hap("true", name="hap-check-fast-ok")
+    with patch.object(
+        type(hap), "rc", new_callable=PropertyMock, return_value=0
+    ), patch("hapless.main.wait_created", return_value=True) as wait_created_mock:
+        hapless._check_fast_failure(hap)
+
+        assert hap.rc == 0
+        wait_created_mock.assert_called_once_with(
+            hap._rc_file,
+            live_context=ANY,
+            interval=ANY,
+            timeout=ANY,
+        )
+
+    captured = capsys.readouterr()
+    assert "Hap exited too quickly" in captured.out
+    assert "Hap is healthy" not in captured.out

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -10,8 +10,8 @@ from hapless.ui import ConsoleUI
 
 
 @pytest.fixture
-def hapless_with_ui(tmpdir) -> Generator[Hapless, None, None]:
-    yield Hapless(hapless_dir=Path(tmpdir), quiet=False)
+def hapless_with_ui(tmp_path) -> Generator[Hapless, None, None]:
+    yield Hapless(hapless_dir=tmp_path, quiet=False)
 
 
 def test_default_formatter_is_table():
@@ -103,14 +103,13 @@ def test_rename_message(hapless_with_ui: Hapless, capsys):
 
 
 def test_workdir_is_displayed_in_versbose_mode(
-    hapless_with_ui: Hapless, tmpdir, capsys
+    hapless_with_ui: Hapless, tmp_path, capsys
 ):
     hapless = hapless_with_ui
-    workdir = Path(tmpdir)
-    hap = hapless.create_hap("true", workdir=workdir)
+    hap = hapless.create_hap("true", workdir=tmp_path)
     hapless.show(hap, formatter=TableFormatter(verbose=True))
 
     captured = capsys.readouterr()
     assert "Command:" in captured.out
     assert "Working dir:" in captured.out
-    assert f"{workdir}" in captured.out  # Check for the title
+    assert f"{tmp_path}" in captured.out  # Check for the title

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -105,7 +105,7 @@ def test_rename_message(hapless_with_ui: Hapless, capsys):
     assert "new-name" in captured.out
 
 
-def test_workdir_is_displayed_in_versbose_mode(
+def test_workdir_is_displayed_in_verbose_mode(
     hapless_with_ui: Hapless, tmp_path, capsys
 ):
     hapless = hapless_with_ui
@@ -115,7 +115,7 @@ def test_workdir_is_displayed_in_versbose_mode(
     captured = capsys.readouterr()
     assert "Command:" in captured.out
     assert "Working dir:" in captured.out
-    assert f"{tmp_path}" in captured.out  # Check for the title
+    assert f"{tmp_path}" in captured.out
 
 
 def test_launching_message(hapless_with_ui: Hapless, capsys):


### PR DESCRIPTION
### Description
* Allow storing working directory, so commands like `restart` have proper context and run same command within same working dir instead of the place of `hap` invocation. Previous behaviour can lead to failed restarts or even unexpected code being run when launched from the wrong folder
* Always print working directory status in a verbose mode, not only when process is running