### PR TITLE
Proper exit from forked process in threading environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.8
+  rev: v0.12.10
   hooks:
   - id: ruff-check
     args: ["--fix"]

--- a/hapless/main.py
+++ b/hapless/main.py
@@ -246,8 +246,9 @@ class Hapless:
             os.setsid()
             logger.debug(f"Running subprocess in child with pid {os.getpid()}")
             self._wrap_subprocess(hap)
-            # NOTE: sole purpose of the child is to run a subprocess
-            sys.exit(0)
+            # NOTE: to prevent deadlocks in multi-threaded environments
+            # https://docs.python.org/3/library/os.html#os._exit
+            os._exit(0)
 
     def run_command(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hapless"
-version = "0.11.0"
+version = "0.11.1"
 description = "Run and track processes in background"
 authors = ["Misha Behersky <bmwant@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Description

Do not use `sys.exit` in a child after the fork as it might lead to deadlocks. Also it cleans ups resources, which can corrupt state of the event loop in the asyncio environment.
Following recommendation `sys.exit` was replaced with direct `os._exit`.
Code also should be safe in multithreading environment as only fork+exec is done in the child.